### PR TITLE
feat: rename TansiveClient to SkillSetClient and update terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tansive™ Python SDK
+# Tansive™ Python SkillSet SDK
 
 The official Python SkillSet™ SDK for Tansive™ - Open Platform for Secure AI Agents.
 
@@ -11,11 +11,11 @@ pip install tansive-skillset-sdk
 ## Quick Start
 
 ```python
-from tansive.skillset_sdk import TansiveClient
+from tansive.skillset_sdk import SkillSetClient
 import uuid
 
 # Initialize the client with a Unix domain socket path
-client = TansiveClient("/tmp/tangent.sock")
+client = SkillSetClient("/tmp/tangent.sock")
 
 # Invoke a skill
 result = client.invoke_skill(
@@ -27,9 +27,9 @@ result = client.invoke_skill(
 
 print(result.output)
 
-# Retrieve tools
-tools = client.get_tools(session_id="550e8400-e29b-41d4-a716-446655440000")
-print(tools)
+# Retrieve skills
+skills = client.get_skills(session_id="550e8400-e29b-41d4-a716-446655440000")
+print(skills)
 
 # Fetch context
 context = client.get_context(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tansive-skillset-sdk"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 description = "Tansive SkillSet SDK"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/tansive/skillset_sdk/__init__.py
+++ b/src/tansive/skillset_sdk/__init__.py
@@ -2,9 +2,9 @@
 Tansive Skillset SDK
 """
 
-__version__ = "0.1.0-alpha.1"
+__version__ = "0.1.0-alpha.2"
 
-from .client import TansiveClient, SkillInvocation, SkillResult
+from .client import SkillSetClient, SkillInvocation, SkillResult
 from .exceptions import (
     TansiveError,
     TansiveConnectionError,
@@ -15,7 +15,7 @@ from .exceptions import (
 )
 
 __all__ = [
-    "TansiveClient",
+    "SkillSetClient",
     "SkillInvocation",
     "SkillResult",
     "TansiveError",

--- a/src/tansive/skillset_sdk/client.py
+++ b/src/tansive/skillset_sdk/client.py
@@ -1,7 +1,7 @@
 """Tansive SkillSet SDK Client
 
 Provides the primary client interface for interacting with the Tansive SkillSet service over
-Unix domain sockets. Handles skill invocation, context access, and tool discovery with
+Unix domain sockets. Handles skill invocation, context access, and skill discovery with
 built-in connection management, retries, and error handling.
 """
 
@@ -100,7 +100,7 @@ class UnixHTTPConnection(http.client.HTTPConnection):
             raise TansiveError(f"Unexpected error during connection: {e}")
 
 
-class TansiveClient:
+class SkillSetClient:
     """Client for interacting with the Tansive SkillSet service.
 
     Handles communication over Unix domain sockets with automatic retries and error handling.
@@ -233,17 +233,17 @@ class TansiveClient:
         except Exception as e:
             raise TansiveError(f"Failed to invoke skill: {e}")
 
-    def get_tools(
+    def get_skills(
         self, session_id: str, ctx: Optional[Any] = None
     ) -> List[Dict[str, Any]]:
-        """Get available tools for the given session.
+        """Get available skills for the given session.
 
         Parameters:
             session_id (str): Session identifier from Tansive service.
             ctx (Optional[Any]): Optional context for the request.
 
         Returns:
-            List[Dict[str, Any]]: Available tools and their configurations.
+            List[Dict[str, Any]]: Available skills and their configurations.
 
         Raises:
             TansiveValidationError: If session_id is missing.
@@ -254,11 +254,11 @@ class TansiveClient:
 
         try:
             query = urlencode({"session_id": session_id})
-            return self._make_request("GET", f"/tools?{query}", ctx=ctx)
+            return self._make_request("GET", f"/skills?{query}", ctx=ctx)
         except TansiveError:
             raise
         except Exception as e:
-            raise TansiveError(f"Failed to get tools: {e}")
+            raise TansiveError(f"Failed to get skills: {e}")
 
     def get_context(
         self, session_id: str, invocation_id: str, name: str, ctx: Optional[Any] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,10 @@
 Tests for the Tansive client.
 """
 
-from tansive.skillset_sdk import TansiveClient
+from tansive.skillset_sdk import SkillSetClient
 
 
 def test_client_initialization():
     """Test that the client can be initialized with a socket path."""
-    client = TansiveClient("/tmp/tangent.sock")
-    assert isinstance(client, TansiveClient)
+    client = SkillSetClient("/tmp/tangent.sock")
+    assert isinstance(client, SkillSetClient)


### PR DESCRIPTION
- Rename main client class from TansiveClient to SkillSetClient
- Update method get_tools() to get_skills() for consistency
- Change API endpoint from /tools to /skills
- Update README examples and documentation
- Bump version to 0.1.0-alpha.2
- Update package description to "Tansive SkillSet SDK"

This change improves naming consistency by using "SkillSet" terminology throughout the SDK instead of mixing "Tansive" and "tools" references.